### PR TITLE
Removing parallel loop over symmetry operations is 10x faster?

### DIFF
--- a/src/BinMD.jl
+++ b/src/BinMD.jl
@@ -2,14 +2,16 @@ import Adapt
 
 function binEvents!(h::Hist3, events::AbstractArray, transforms::Array1{SquareMatrix3c})
     JACC.parallel_for(
-        (length(transforms), size(events, 2)),
-        (n, i, t) -> begin
+        size(events, 2),
+        (i, t) -> begin
             @inbounds begin
-                op = t.transforms[n]
-                v = op * C3[t.events[6, i], t.events[7, i], t.events[8, i]]
-                atomic_push!(t.h, v[1], v[2], v[3], t.events[1, i])
+                for n in 1:t.len
+                    op = t.transforms[n]
+                    v = op * C3[t.events[6, i], t.events[7, i], t.events[8, i]]
+                    atomic_push!(t.h, v[1], v[2], v[3], t.events[1, i])
+		end
             end
         end,
-        (h = h, events, transforms),
+        (h, events, transforms, len = length(transforms)),
     )
 end


### PR DESCRIPTION
Removing the parallel loop over symmetry operations makes binMD 10x faster.